### PR TITLE
Move scryfall search to regex match

### DIFF
--- a/lib/AutoCard.js
+++ b/lib/AutoCard.js
@@ -110,7 +110,6 @@ class _AutoCard extends _TextListener {
       switch (config.linkSource) {
         case Constants.linkSource.magicCardsInfo:
         case Constants.linkSource.scryfall:
-          return processCardNameForScryfall(name)
           return `https://scryfall.com/search?q=name:/(?<=\/\/ |^)${name}(?= \/\/|$)/`
         case Constants.linkSource.comboDeck:
           return 'http://combodeck.net/Query/' + name
@@ -121,9 +120,7 @@ class _AutoCard extends _TextListener {
       }
     })
   }
-  processCardNameForScryfall(cardName) {
 
-  }
   getCardInfo() {
     return cardApi.getCardInfo(this.cardName, this.getConfig())
   }

--- a/lib/AutoCard.js
+++ b/lib/AutoCard.js
@@ -110,7 +110,8 @@ class _AutoCard extends _TextListener {
       switch (config.linkSource) {
         case Constants.linkSource.magicCardsInfo:
         case Constants.linkSource.scryfall:
-          return 'https://scryfall.com/search?q=name:/^' + name + '$/'
+          return processCardNameForScryfall(name)
+          return `https://scryfall.com/search?q=name:/^${name}$|(?<=\/\/ )${name}$|^${name}(?= \/\/)/`
         case Constants.linkSource.comboDeck:
           return 'http://combodeck.net/Query/' + name
         case Constants.linkSource.urzaCo:
@@ -119,6 +120,9 @@ class _AutoCard extends _TextListener {
           return 'http://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=' + mid
       }
     })
+  }
+  processCardNameForScryfall(cardName) {
+
   }
   getCardInfo() {
     return cardApi.getCardInfo(this.cardName, this.getConfig())

--- a/lib/AutoCard.js
+++ b/lib/AutoCard.js
@@ -110,7 +110,7 @@ class _AutoCard extends _TextListener {
       switch (config.linkSource) {
         case Constants.linkSource.magicCardsInfo:
         case Constants.linkSource.scryfall:
-          return 'https://scryfall.com/search?q=name:/' + name + '/'
+          return 'https://scryfall.com/search?q=name:/^' + name + '$/'
         case Constants.linkSource.comboDeck:
           return 'http://combodeck.net/Query/' + name
         case Constants.linkSource.urzaCo:

--- a/lib/AutoCard.js
+++ b/lib/AutoCard.js
@@ -111,7 +111,7 @@ class _AutoCard extends _TextListener {
         case Constants.linkSource.magicCardsInfo:
         case Constants.linkSource.scryfall:
           return processCardNameForScryfall(name)
-          return `https://scryfall.com/search?q=name:/^${name}$|(?<=\/\/ )${name}$|^${name}(?= \/\/)/`
+          return `https://scryfall.com/search?q=name:/(?<=\/\/ |^)${name}(?= \/\/|$)/`
         case Constants.linkSource.comboDeck:
           return 'http://combodeck.net/Query/' + name
         case Constants.linkSource.urzaCo:

--- a/lib/AutoCard.js
+++ b/lib/AutoCard.js
@@ -110,7 +110,7 @@ class _AutoCard extends _TextListener {
       switch (config.linkSource) {
         case Constants.linkSource.magicCardsInfo:
         case Constants.linkSource.scryfall:
-          return 'https://scryfall.com/search?q=' + name
+          return 'https://scryfall.com/search?q=name:/' + name + '/'
         case Constants.linkSource.comboDeck:
           return 'http://combodeck.net/Query/' + name
         case Constants.linkSource.urzaCo:


### PR DESCRIPTION
Motivation:

First, the current search scheme doesn't get you directly to the specified card if the card name is contained in other card names. e.g. searching for `Recall` gets us a page with Ancestral Recall, Hurkyl's Recall, and Recall. Moving to a _specific_ search alleviates this issue.

Second, if we try to go with `https://scryfall.com/search?q=!"$STRING"` (Scryfall's exact name match), we encounter the following problem.

Javascript's native encodeURIComponent doesn't encode things in a way that covers every case for Scryfall's backend.
That is, if you wrap the string in `'`, then a specific query on, say, `Steelshaper's Gift` will fail.
Similarly, if you wrap the string in `"`, then a specific query on `"Kongming, "Sleeping Dragon"` will fail.

By shipping the name to the Scryfall regex engine, and bounding it by `^` and `$`, we _guarantee_ that the name will be processed properly.

**NB**: This does require that the user type the name accurately, but then... well, good. It should absolutely do that.