### PR TITLE
Ensure raw regex is passed to scryfall.

### DIFF
--- a/lib/AutoCard.js
+++ b/lib/AutoCard.js
@@ -110,7 +110,7 @@ class _AutoCard extends _TextListener {
       switch (config.linkSource) {
         case Constants.linkSource.magicCardsInfo:
         case Constants.linkSource.scryfall:
-          return `https://scryfall.com/search?q=name:/(?<=\/\/ |^)${name}(?= \/\/|$)/`
+          return String.raw`https://scryfall.com/search?q=name:/(?<=\/\/ |^)${name}(?= \/\/|$)/`
         case Constants.linkSource.comboDeck:
           return 'http://combodeck.net/Query/' + name
         case Constants.linkSource.urzaCo:


### PR DESCRIPTION
Didn't thoroughly vet this on the first pass, 100% my fault. When the original string was passed to Scryfall, the regex was malformed because JavaScript was trying to helpful.

`String.raw` ensures that the regex is actually passed over properly. Built and tested this time, even.

